### PR TITLE
Remove version from output, update base path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,8 +12,7 @@ const winston = require('winston')
 const errorReporter = require('./error-reporter')
 const environment = require('@balena/jellyfish-environment')
 const assert = require('@balena/jellyfish-assert')
-const packageJSON = require('../package.json')
-const BASE_PATH = path.join(__dirname, '..')
+const BASE_PATH = path.join(__dirname, '..', '..', '..')
 
 // Adds winston.transports.Logentries
 require('le_node')
@@ -60,7 +59,6 @@ class Logger {
 
 		this.logger.log('debug', message, {
 			namespace: this.namespace,
-			version: packageJSON.version,
 			context,
 			data
 		})
@@ -73,7 +71,6 @@ class Logger {
 
 		this.logger.log('crit', message, {
 			namespace: this.namespace,
-			version: packageJSON.version,
 			context,
 			data
 		})
@@ -86,7 +83,6 @@ class Logger {
 
 		this.logger.log('warning', message, {
 			namespace: this.namespace,
-			version: packageJSON.version,
 			context,
 			data
 		})
@@ -99,7 +95,6 @@ class Logger {
 
 		this.logger.log('info', message, {
 			namespace: this.namespace,
-			version: packageJSON.version,
 			context,
 			data
 		})
@@ -139,7 +134,7 @@ const newTransport = () => {
 					})
 
 				const id = info.context.id
-				const prefix = `(${info.version}) ${info.timestamp} [${info.namespace}] [${info.level}] [${id}]:`
+				const prefix = `${info.timestamp} [${info.namespace}] [${info.level}] [${id}]:`
 				if (info.data) {
 					return `${prefix} ${info.message} ${JSON.stringify(info.data)}`
 				}

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -5,7 +5,6 @@
  */
 
 const ava = require('ava')
-const _ = require('lodash')
 const logger = require('./index')
 
 ava('.getLogger() returns a logger instance', async (test) => {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

- Remove `packageJSON.version` from log output as this now refers to this packages version and not Jellyfish
- Update base path to reflect new file locations