### PR TITLE
Use Node v14 during CI tests

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -4,4 +4,4 @@ npm:
       os: alpine
       architecture: x86_64
       node_versions:
-        - "12"
+        - "14"


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

We are using Node v14 in production and should be doing the same during CI tests.