### PR TITLE
Allow override of publish_dir property in workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -35,5 +35,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs
+          publish_dir: ${{ secrets.PUBLISH_DIR }} || docs
           publish_branch: docs


### PR DESCRIPTION
Repo should be able to optionally set the `PUBLISH_DIR` secret and have that value used.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>