### PR TITLE
Internalize strip-ansi

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
   },
   "devDependencies": {
     "@balena/jellycheck": "^0.1.1",
-    "@balena/lint": "^6.1.1",
     "@balena/jellyfish-config": "^1.2.5",
+    "@balena/lint": "^6.1.1",
     "@types/intercept-stdout": "^0.1.0",
     "@types/jest": "^26.0.23",
     "@types/lodash": "^4.14.170",
@@ -69,7 +69,6 @@
     "lint-staged": "^11.0.0",
     "sentry-testkit": "^3.3.2",
     "simple-git-hooks": "^2.4.1",
-    "strip-ansi": "^6.0.0",
     "ts-jest": "^27.0.1",
     "typedoc": "^0.20.36",
     "typescript": "^4.3.2"

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -5,12 +5,24 @@
  */
 
 import intercept = require('intercept-stdout');
-import stripAnsi = require('strip-ansi');
 import { getLogger } from '../lib/index';
 
 const TEST_CONTEXT = {
 	id: 1,
 };
+
+function ansiRegex({ onlyFirst = false } = {}) {
+	const pattern = [
+		'[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+		'(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))',
+	].join('|');
+
+	return new RegExp(pattern, onlyFirst ? undefined : 'g');
+}
+
+function stripAnsi(output: string): string {
+	return output.replace(ansiRegex(), '');
+}
 
 test('getLogger() returns a logger instance', () => {
 	const instance = getLogger(__filename);


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

The `strip-ansi` module has converted to an ESM module. Tried updating the necessary bits to allow `jellyfish-logger` to import ESM modules, but I think it's more trouble than its worth, especially if all we're getting for it is `strip-ansi`.