### PR TITLE
Stop logging to rapid7 and rely on stdout instead

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -18,10 +18,6 @@ type LogContext = object | null;
 const BASE_PATH = path.join(__dirname, '..', '..', '..');
 const errorReporter = getErrorReporter();
 
-// Adds winston.transports.Insight
-// tslint:disable-next-line: no-var-requires
-require('r7insight_node');
-
 const LoggerNoContext = typedErrors.makeTypedError('LoggerNoContext');
 
 // See https://github.com/winstonjs/winston#logging-levels for more information
@@ -136,22 +132,7 @@ class Logger {
 	}
 }
 
-// TODO: Replace references to "logentries" to "insight".
 const newTransport = (): winston.transport => {
-	if (
-		defaultEnvironment.isProduction() &&
-		defaultEnvironment.logentries.token
-	) {
-		// winston.transports.Insight is populated by requiring 'r7insight_node'. But
-		// TypeScript does not know about it! There is also no TypeScript definition
-		// for this transport class in the r7insight_node package.
-		const InsightTransport = _.get(winston.transports, ['Insight']);
-		return new InsightTransport({
-			token: defaultEnvironment.logentries.token,
-			region: defaultEnvironment.logentries.region,
-		});
-	}
-
 	const consoleTransport = new winston.transports.Console({
 		format: winston.format.combine(
 			winston.format.colorize(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -2540,14 +2540,6 @@
       "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ==",
       "dev": true
     },
-    "backoff": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
-      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
-      "requires": {
-        "precond": "0.2"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -2808,21 +2800,6 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
-    },
-    "codependency": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/codependency/-/codependency-2.1.0.tgz",
-      "integrity": "sha512-JIdmYkE8Z6jwH1OUf4a5H5jk9YShPQkaYPUAiN+ktyChmPP77LGbeKrxWGPqdCnpTmt0hRIn8TXBVu01U3HDhg==",
-      "requires": {
-        "semver": "^5.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -6748,11 +6725,6 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
     "json5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -7802,11 +7774,6 @@
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
     },
-    "precond": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
-      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -7910,17 +7877,6 @@
         "lodash": "^4.17.15"
       }
     },
-    "r7insight_node": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/r7insight_node/-/r7insight_node-3.0.1.tgz",
-      "integrity": "sha512-infl8EOMK88HPfB9h6r8ffnO72S7Dx2DUkzMwNFZ+1pUYV5ARZRanQOU2GumQdy7/0K/fh+uivfFG9pmty0jFw==",
-      "requires": {
-        "codependency": "^2.1.0",
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
-        "reconnect-core": "^1.3.0"
-      }
-    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -7991,14 +7947,6 @@
       "dev": true,
       "requires": {
         "resolve": "^1.1.6"
-      }
-    },
-    "reconnect-core": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/reconnect-core/-/reconnect-core-1.3.0.tgz",
-      "integrity": "sha1-+65SkZp4d9hE4yRtAaLyZwHIM8g=",
-      "requires": {
-        "backoff": "~2.5.0"
       }
     },
     "require-directory": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@sentry/node": "^6.4.1",
     "errio": "^1.2.2",
     "lodash": "^4.17.21",
-    "r7insight_node": "^3.0.1",
     "typed-errors": "^1.1.0",
     "winston": "^3.3.3",
     "winston-transport": "^4.4.0"


### PR DESCRIPTION
Balena has standardised on logging to stdout and using tools to capture
and store the output instead of having application code log to an
external service directly. This change follows this pattern and removes
the direct logging to r7.

Change-type: major
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>