### PR TITLE
Do not handle uncaught exceptions

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -66,7 +66,6 @@ class Logger {
 				winston.format.json(),
 			),
 			transports: [transport],
-			exceptionHandlers: [transport],
 			exitOnError: false,
 			level,
 		});


### PR DESCRIPTION
When winston is configured to handle uncaught exceptions, all uncaught
exceptions will result in a `LoggerNoContext` error being thrown, which
obscure the real source of the error and makes it very hard to debug
problems. Additionally, this behaviour interferes with application level
exception handling.

Change-type: major
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>